### PR TITLE
Fixed nginx.xml server template to work with 1.8

### DIFF
--- a/server_template/nginx.xml
+++ b/server_template/nginx.xml
@@ -18,7 +18,7 @@
       <groups>
         <group>Templates</group>
       </groups>
-      <triggers/>
+      <triggers>
         <trigger>
           <description>Nginx is not running on {HOSTNAME}</description>
           <type>0</type>


### PR DESCRIPTION
I had error importing nginx.xml into zabbix:
ERROR: Import failed
XML file contains errors. Fatal Error 76: Opening and ending tag mismatch: host line 4 and triggers [ Line: 38 | Column: 18 ]

This patch fixes it.
